### PR TITLE
修复: Docker 镜像名强制转小写

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -33,6 +32,9 @@ jobs:
     steps:
       - name: 检出代码
         uses: actions/checkout@v4
+
+      - name: 设置镜像名（转小写）
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: 设置 Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -85,6 +87,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: 设置镜像名（转小写）
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: 下载 digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## 问题

Docker 镜像仓库名必须全小写，但 `github.repository` 会保留原始大小写。

当用户名包含大写字母（如 `Kylsky`）时，构建会报错：
```
invalid reference format: repository name (Kylsky/chatgpt-team-helper) must be lowercase
```

## 修复方案

在 build 和 merge job 中使用 Bash 参数扩展将仓库名转为小写：
```bash
echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
```

## 测试

修复后镜像名将正确转换为 `ghcr.io/kylsky/chatgpt-team-helper`。