### PR TITLE
添加多架构 Docker 镜像自动构建支持 (GHCR)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,141 @@
+name: 构建并推送多架构 Docker 镜像
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    outputs:
+      image-name: ${{ steps.set-image-name.outputs.image-name }}
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 设置镜像名（转小写）
+        id: set-image-name
+        run: |
+          IMAGE_NAME="${GITHUB_REPOSITORY,,}"
+          echo "image-name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+
+      - name: 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 登录 GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 提取 Docker 元数据
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: 构建并推送（按架构）
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: 导出 digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: 上传 digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: 设置镜像名（转小写）
+        run: |
+          IMAGE_NAME="${GITHUB_REPOSITORY,,}"
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+
+      - name: 下载 digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 登录 GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 提取 Docker 元数据
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: 创建并推送 manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${REGISTRY}/${IMAGE_NAME}@sha256:%s " *)
+
+      - name: 检查镜像
+        run: |
+          docker buildx imagetools inspect ${REGISTRY}/${IMAGE_NAME}:${{ steps.meta.outputs.version }}

--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# 本地多架构 Docker 镜像构建脚本
+# 使用方法: ./build-multiarch.sh
+# 环境变量:
+#   IMAGE_NAME - 镜像名称 (默认: kylsky/auto-gpt-team)
+#   TAG - 镜像标签 (默认: latest)
+#   PLATFORMS - 目标平台 (默认: linux/amd64,linux/arm64)
+#   PUSH - 是否推送到 Docker Hub (默认: false)
+
+set -euo pipefail
+
+IMAGE_NAME="${IMAGE_NAME:-ghcr.io/kylsky/chatgpt-team-helper}"
+TAG="${TAG:-latest}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+PUSH="${PUSH:-false}"
+
+# 颜色定义
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}✓${NC} $1"; }
+print_error() { echo -e "${RED}✗${NC} $1"; }
+print_warning() { echo -e "${YELLOW}⚠${NC} $1"; }
+
+echo "======================================"
+echo "    多架构 Docker 镜像构建"
+echo "======================================"
+echo "镜像名称: ${IMAGE_NAME}:${TAG}"
+echo "目标平台: ${PLATFORMS}"
+echo "推送镜像: ${PUSH}"
+echo ""
+
+# 检查 docker buildx
+if ! docker buildx version > /dev/null 2>&1; then
+    print_error "未安装 docker buildx"
+    echo "请升级 Docker 到最新版本或安装 buildx 插件"
+    exit 1
+fi
+print_success "docker buildx 已安装"
+
+# 创建或使用 builder
+BUILDER_NAME="multiarch-builder"
+if ! docker buildx inspect "${BUILDER_NAME}" > /dev/null 2>&1; then
+    echo "创建 buildx builder: ${BUILDER_NAME}"
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container --use
+    docker buildx inspect "${BUILDER_NAME}" --bootstrap
+    print_success "builder 创建完成"
+else
+    docker buildx use "${BUILDER_NAME}"
+    print_success "使用已有 builder: ${BUILDER_NAME}"
+fi
+
+# 构建参数
+BUILD_ARGS=(
+    --platform "${PLATFORMS}"
+    --tag "${IMAGE_NAME}:${TAG}"
+)
+
+if [ "${PUSH}" = "true" ]; then
+    BUILD_ARGS+=(--push)
+    print_warning "将推送到 Docker Hub..."
+else
+    echo "仅构建，不推送（设置 PUSH=true 推送）"
+    BUILD_ARGS+=(--output type=image,push=false)
+fi
+
+# 执行构建
+echo ""
+echo "开始构建..."
+echo "------------------------"
+docker buildx build "${BUILD_ARGS[@]}" .
+
+echo ""
+echo "======================================"
+echo "    构建完成！"
+echo "======================================"
+
+if [ "${PUSH}" = "true" ]; then
+    echo ""
+    print_success "镜像已推送到 Docker Hub"
+    echo ""
+    echo "验证多架构镜像："
+    echo "  docker buildx imagetools inspect ${IMAGE_NAME}:${TAG}"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.8'
 
 services:
   app:
-    image: auto-gpt-team:latest
-    # image: kylsky/auto-gpt-team:latest
+    image: ghcr.io/kylsky/chatgpt-team-helper:latest
+    # 或使用本地构建: image: auto-gpt-team:latest
     container_name: auto-gpt-team
     ports:
       - "5173:5173" # 前端 Web 端口（API 通过 nginx 代理，无需暴露 3000）


### PR DESCRIPTION
## 功能说明

为项目添加多架构 Docker 镜像自动构建能力，支持 `linux/amd64` 和 `linux/arm64` 架构。

## 变更内容

### 新增文件

**`.github/workflows/docker-publish.yml`** - GitHub Actions 多架构构建工作流
- 触发条件：推送到 main 分支或创建 `v*` 标签
- 使用原生 Runner 构建（amd64 用 ubuntu-latest，arm64 用 ubuntu-24.04-arm）
- 镜像名自动转小写，兼容大写用户名（解决 `Kylsky` → `kylsky` 的问题）
- 镜像推送到 GitHub Container Registry (GHCR)

**`build-multiarch.sh`** - 本地多架构构建脚本（可选使用）

### 修改文件

**`docker-compose.yml`** - 默认使用 GHCR 镜像

## 使用方式

构建完成后，用户可以直接拉取镜像：

```bash
docker pull ghcr.io/kylsky/chatgpt-team-helper:latest
```

Docker 会自动选择匹配当前机器架构的版本（x86_64 或 ARM64）。

## 技术细节

- 使用 `${GITHUB_REPOSITORY,,}` Bash 参数扩展强制转小写，避免大写用户名导致的构建失败
- 两阶段构建：先分别构建各架构，再合并为多架构 manifest
- 使用 GitHub Actions 缓存加速后续构建